### PR TITLE
feat: re-enable check for installed Helium App

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,6 +11,12 @@
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
 
+    <queries>
+       <intent>
+          <action android:name="android.intent.action.VIEW" />
+          <data android:scheme="helium" android:host="*" />
+      </intent>
+    </queries>
     <!-- Add this line if your application always requires BLE. More info can be found on:
 
       https://developer.android.com/guide/topics/connectivity/bluetooth-le.html#permissions -->

--- a/src/features/hotspots/setup/HotspotSetupEducationScreen.tsx
+++ b/src/features/hotspots/setup/HotspotSetupEducationScreen.tsx
@@ -55,7 +55,7 @@ const HotspotEducationScreen = () => {
     }
     return (
       <DebouncedButton
-        variant="secondary"
+        variant="primary"
         mode="text"
         onPress={navNext}
         title={t('generic.skip')}

--- a/src/features/onboarding/LinkAccount.tsx
+++ b/src/features/onboarding/LinkAccount.tsx
@@ -1,13 +1,13 @@
 import React, { memo, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { WalletLink } from '@helium/react-native-sdk'
-import { Linking, Platform } from 'react-native'
+import { Linking, Platform, Alert } from 'react-native'
 import { getBundleId } from 'react-native-device-info'
 import SafeAreaBox from '../../components/SafeAreaBox'
 import Text from '../../components/Text'
 import Box from '../../components/Box'
 import TouchableOpacityBox from '../../components/TouchableOpacityBox'
-// import { locale } from '../../utils/i18n'
+import { locale } from '../../utils/i18n'
 
 const LinkAccount = () => {
   const { t } = useTranslation()
@@ -22,34 +22,35 @@ const LinkAccount = () => {
           callbackUrl: 'makerappscheme://',
           appName: 'Nebra Hotspot',
         })
-        // Checking if the wallet URL scheme can be opened.
-        // const supported = await Linking.canOpenURL(url)
-        // if (supported) {
-        Linking.openURL(url)
-        // } else {
-        //   Alert.alert(
-        //     'Helium App Not Found',
-        //     'You must have the official Helium app installed.',
-        //     [
-        //       {
-        //         text: 'Cancel',
-        //         style: 'cancel',
-        //       },
-        //       {
-        //         text: 'Get Helium App',
-        //         onPress: () => {
-        //           if (Platform.OS === 'android') {
-        //             Linking.openURL(`market://details?id=${app.androidPackage}`)
-        //           } else if (Platform.OS === 'ios') {
-        //             Linking.openURL(
-        //               `https://apps.apple.com/${locale}/app/${app.name}/id${app.appStoreId}`,
-        //             )
-        //           }
-        //         },
-        //       },
-        //     ],
-        //   )
-        // }
+
+        // Check if the wallet URL scheme can be opened.
+        const supported = await Linking.canOpenURL(url)
+        if (supported) {
+          Linking.openURL(url)
+        } else {
+          Alert.alert(
+            'Helium App Not Found',
+            'You must have the official Helium app installed.',
+            [
+              {
+                text: 'Cancel',
+                style: 'cancel',
+              },
+              {
+                text: 'Get Helium App',
+                onPress: () => {
+                  if (Platform.OS === 'android') {
+                    Linking.openURL(`market://details?id=${app.androidPackage}`)
+                  } else if (Platform.OS === 'ios') {
+                    Linking.openURL(
+                      `https://apps.apple.com/${locale}/app/${app.name}/id${app.appStoreId}`,
+                    )
+                  }
+                },
+              },
+            ],
+          )
+        }
       } catch (error) {
         // eslint-disable-next-line no-console
         console.error(error)

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -295,16 +295,16 @@ export default {
     },
   },
   hotspots: {
-    view_activity: 'After adding a Hotspot, you can view your account on the ',
-    explorer: 'Helium Explorer',
+    view_activity: 'After adding a hotspot, you can view your account on the ',
+    explorer: 'Helium Explorer or Helium Wallet',
     empty: {
-      body: 'Your add hotspot\ninstructions',
+      body: 'Follow these instructions to setup your hotspot.',
       hotspots: {
         add: 'Add Hotspot',
         assertLocation: 'Assert Location',
         transfer: 'Transfer Hotspot',
       },
-      title: 'Add a\nNebra Hotspot',
+      title: 'Nebra Hotspot Setup',
     },
   },
   learn: {


### PR DESCRIPTION
**Issue**

- Link: https://github.com/NebraLtd/maker-starter-app/pull/39/files
- Summary: Enable notification if Helium App not installed.

**How**
https://stackoverflow.com/questions/64699801/linking-canopenurl-returning-false-when-targeting-android-30-sdk-on-react-native

**Screenshots**

<!-- Include images, if possible. -->

**References**

<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names
