### PR TITLE
Use different bundle name

### DIFF
--- a/android/app/_BUCK
+++ b/android/app/_BUCK
@@ -35,12 +35,12 @@ android_library(
 
 android_build_config(
     name = "build_config",
-    package = "com.nebra.helium.app",
+    package = "com.nebra.helium.maker",
 )
 
 android_resource(
     name = "res",
-    package = "com.nebra.helium.app",
+    package = "com.nebra.helium.maker",
     res = "src/main/res",
 )
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -173,7 +173,7 @@ android {
     }
 
     defaultConfig {
-        applicationId "com.nebra.helium.app"
+        applicationId "com.nebra.helium.maker"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode getVersionCode()

--- a/android/app/src/debug/java/com/nebra/helium/maker/ReactNativeFlipper.java
+++ b/android/app/src/debug/java/com/nebra/helium/maker/ReactNativeFlipper.java
@@ -4,7 +4,7 @@
  * <p>This source code is licensed under the MIT license found in the LICENSE file in the root
  * directory of this source tree.
  */
-package com.nebra.helium.app;
+package com.nebra.helium.maker;
 
 import android.content.Context;
 import com.facebook.flipper.android.AndroidFlipperClient;

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.nebra.helium.app"
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.nebra.helium.maker"
           xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />

--- a/android/app/src/main/java/com/nebra/helium/maker/MainActivity.java
+++ b/android/app/src/main/java/com/nebra/helium/maker/MainActivity.java
@@ -1,4 +1,4 @@
-package com.nebra.helium.app;
+package com.nebra.helium.maker;
 import expo.modules.ReactActivityDelegateWrapper;
 import com.facebook.react.ReactActivityDelegate;
 

--- a/android/app/src/main/java/com/nebra/helium/maker/MainApplication.java
+++ b/android/app/src/main/java/com/nebra/helium/maker/MainApplication.java
@@ -1,4 +1,4 @@
-package com.nebra.helium.app;
+package com.nebra.helium.maker;
 import android.content.res.Configuration;
 import expo.modules.ApplicationLifecycleDispatcher;
 import expo.modules.ReactNativeHostWrapper;
@@ -72,7 +72,7 @@ public class MainApplication extends Application implements ReactApplication {
          * We use reflection here to pick up the class that initializes Flipper, since
          * Flipper library is not available in release mode
          */
-        Class<?> aClass = Class.forName("com.nebra.helium.app.ReactNativeFlipper");
+        Class<?> aClass = Class.forName("com.nebra.helium.maker.ReactNativeFlipper");
         aClass.getMethod("initializeFlipper", Context.class, ReactInstanceManager.class).invoke(null, context,
             reactInstanceManager);
       } catch (ClassNotFoundException e) {

--- a/android/app/src/main/java/com/nebra/helium/maker/MakerAppPackage.java
+++ b/android/app/src/main/java/com/nebra/helium/maker/MakerAppPackage.java
@@ -1,4 +1,4 @@
-package com.nebra.helium.app;
+package com.nebra.helium.maker;
 
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.NativeModule;


### PR DESCRIPTION
**Issue**

- Link: https://github.com/NebraLtd/maker-starter-app/issues/73
- Summary: 
To submit the Android app to google store, use a different Android bundle name than before since using the original Android bundle name we can not submit to the Google store due to the certification error.

**How**
- Original Android bundle name: `com.nebra.helium.app`
- Updated Android bundle name: `com.nebra.helium.maker`

<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**

<!-- Include images, if possible. -->

**References**

<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names
