### PR TITLE
Change iOS bundle ID

### DIFF
--- a/ios/Nebra.xcodeproj/project.pbxproj
+++ b/ios/Nebra.xcodeproj/project.pbxproj
@@ -372,7 +372,7 @@
 						TestTargetID = 13B07F861A680F5B00A75B9A;
 					};
 					13B07F861A680F5B00A75B9A = {
-						DevelopmentTeam = 9L5L9YJKV3;
+						DevelopmentTeam = SDV42U7N4S;
 						LastSwiftMigration = 1250;
 					};
 				};
@@ -693,8 +693,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Nebra/Nebra.entitlements;
-				CURRENT_PROJECT_VERSION = 6;
-				DEVELOPMENT_TEAM = 9L5L9YJKV3;
+				CURRENT_PROJECT_VERSION = 8;
+				DEVELOPMENT_TEAM = SDV42U7N4S;
 				ENABLE_BITCODE = NO;
 				EXCLUDED_ARCHS = "";
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
@@ -706,7 +706,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.nebra.helium.app;
+				PRODUCT_BUNDLE_IDENTIFIER = com.nebra.helium.maker;
 				PRODUCT_NAME = Nebra;
 				SWIFT_OBJC_BRIDGING_HEADER = "Nebra-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -724,7 +724,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Nebra/NebraRelease.entitlements;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = SDV42U7N4S;
 				EXCLUDED_ARCHS = "";
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
@@ -736,7 +736,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.nebra.helium;
+				PRODUCT_BUNDLE_IDENTIFIER = com.nebra.helium.maker;
 				PRODUCT_NAME = Nebra;
 				SWIFT_OBJC_BRIDGING_HEADER = "Nebra-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
**Issue**

- Link:https://github.com/NebraLtd/maker-starter-app/issues/15
- Summary: To submit the iOS app to app store, use a different iOS bundle id. 

**How**

Original Android bundle name: com.nebra.helium
Updated Android bundle name: com.nebra.helium.maker




<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**

<!-- Include images, if possible. -->

**References**

<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names
