### PR TITLE
Content fit on Home screen

### DIFF
--- a/src/features/hotspots/root/HotspotsScreen.tsx
+++ b/src/features/hotspots/root/HotspotsScreen.tsx
@@ -49,7 +49,7 @@ const HotspotsScreen = () => {
             flexDirection: 'column',
           }}
         >
-          <Box style={{ flex: 1.5 }} justifyContent="center">
+          <Box style={{ flex: 1.8 }} justifyContent="center">
             <CircularButton
               onPress={addHotspot}
               height={90}


### PR DESCRIPTION
**Issue**

- Link: https://github.com/NebraLtd/maker-starter-app/issues/79
- Summary: Circular button wasn't fitting on screen. 

**How**
- Increased the  flex of the circular button box

<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**

![Simulator Screen Shot - iPhone 13 - 2022-04-03 at 17 07 33](https://user-images.githubusercontent.com/20680743/161510872-46b2738a-d530-44d4-bae2-7b405f34fa34.png)

<!-- Include images, if possible. -->

**References**

<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names
