### PR TITLE
iOS Bluetooth Permission message update

### DIFF
--- a/ios/Nebra/Info.plist
+++ b/ios/Nebra/Info.plist
@@ -55,7 +55,7 @@
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>Allow Nebra Hotspot to connect to and manage your Hotspots</string>
 	<key>NSBluetoothPeripheralUsageDescription</key>
-	<string>Allow Nebra Hotspot to connect to and manage your Hotspots</string>
+	<string>Allow Nebra Hotspot App to use your Bluetooth to connect to and onboard your hotspot</string>
 	<key>NSCameraUsageDescription</key>
 	<string>Allow Nebra Hotspot to use your camera to add hotspots</string>
 	<key>NSFaceIDUsageDescription</key>


### PR DESCRIPTION
**Issue**

- Link:https://github.com/NebraLtd/maker-starter-app/issues/98
- Summary: iOS Bluetooth access message doesn’t sufficiently explain the use of the Bluetooth in the purpose string.



**How**

<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**

<!-- Include images, if possible. -->

**References**

<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names
