### PR TITLE
Fix Wifi password textbox color

### DIFF
--- a/src/features/hotspots/setup/HotspotSetupWifiScreen.tsx
+++ b/src/features/hotspots/setup/HotspotSetupWifiScreen.tsx
@@ -71,7 +71,7 @@ const HotspotSetupWifiScreen = () => {
           </Box>
           <TextInput
             padding="m"
-            variant="regular"
+            variant="secondary"
             placeholder={t('hotspot_setup.wifi_password.placeholder')}
             onChangeText={setPassword}
             value={password}


### PR DESCRIPTION
**Issue**

- Link: https://github.com/NebraLtd/maker-starter-app/issues/111
- Summary:
 As a user, I can recognize the password length and transient appearance of characters.

**How**

<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**
![image](https://user-images.githubusercontent.com/91350131/164213329-c0bcfa84-dedf-4798-8d23-991aebc8c6b3.png)


<!-- Include images, if possible. -->

**References**

<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names
