### PR TITLE
Set marker location to Hotspot location when asserting location

### DIFF
--- a/src/features/hotspots/setup/HotspotSetupPickLocationScreen.tsx
+++ b/src/features/hotspots/setup/HotspotSetupPickLocationScreen.tsx
@@ -33,6 +33,7 @@ import BSHandle from '../../../components/BSHandle'
 import AddressSearchModal from './AddressSearchModal'
 import { PlaceGeography } from '../../../utils/googlePlaces'
 import useGetLocation from '../../../utils/useGetLocation'
+import { getHotspotDetails } from '../../../utils/appDataClient'
 
 type Route = RouteProp<
   HotspotSetupStackParamList,
@@ -65,7 +66,7 @@ const HotspotSetupPickLocationScreen = () => {
 
     checkLocationPermissions()
     sleepThenEnable()
-  }, [maybeGetLocation])
+  }, [maybeGetLocation, params])
 
   const onMapMoved = useCallback(async (newCoords?: Position) => {
     if (newCoords) {
@@ -87,11 +88,16 @@ const HotspotSetupPickLocationScreen = () => {
   }, [locationName, markerCenter, navigation, params])
 
   const onDidFinishLoadingMap = useCallback(
-    (latitude: number, longitude: number) => {
+    async (latitude: number, longitude: number) => {
+      const hotspot = await getHotspotDetails(params.hotspotAddress)
+      const defaultLocation =
+        hotspot?.lng && hotspot?.lat
+          ? [hotspot?.lng, hotspot?.lat]
+          : [longitude, latitude]
       setHasGPSLocation(true)
-      setMapCenter([longitude, latitude])
+      setMapCenter(defaultLocation)
     },
-    [],
+    [params],
   )
 
   const handleSearchPress = useCallback(() => {


### PR DESCRIPTION
**Issue**

- Link: https://github.com/NebraLtd/maker-starter-app/issues/130
- Summary:When asserting hotspot location, the map marker is set to the user's current location. The PR satisfy the AC of 
    - If the hotspot's location has previously been asserted, the map marker should by default point to the current hotspot location
    - If the hotspot's location has never been asserted, the marker should point to the current user location

**How**

<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**

<!-- Include images, if possible. -->

**References**

<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names
