### PR TITLE
Display notification that Helium App must be installed from official store

### DIFF
--- a/src/features/onboarding/LinkAccount.tsx
+++ b/src/features/onboarding/LinkAccount.tsx
@@ -30,7 +30,7 @@ const LinkAccount = () => {
         } else {
           Alert.alert(
             'Helium App Not Found',
-            'You must have the official Helium app installed.',
+            'You must have the Helium app installed from official App Store.',
             [
               {
                 text: 'Cancel',


### PR DESCRIPTION
**Issue**

- Link: https://github.com/NebraLtd/maker-starter-app/issues/151
- Summary:
If Helium App installed not from the official play store, the maker app couldn't find it.
The maker app needs to display about this explicitly to the users.

**How**

<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**
![image](https://user-images.githubusercontent.com/91350131/168708971-7863ba66-51cb-4b98-b22e-9388320b63e9.png)

<!-- Include images, if possible. -->

**References**

<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names
