### PR TITLE
Fix stucking while getting the hotspot details

### DIFF
--- a/src/features/hotspots/setup/HotspotSetupBluetoothSuccess.tsx
+++ b/src/features/hotspots/setup/HotspotSetupBluetoothSuccess.tsx
@@ -16,10 +16,8 @@ import {
 } from './hotspotSetupTypes'
 import useAlert from '../../../utils/useAlert'
 import { HotspotEvents } from '../../../utils/analytics/events'
-import { getHotspotDetails } from '../../../utils/appDataClient'
 import { useAppDispatch } from '../../../store/store'
 import hotspotOnboardingSlice from '../../../store/hotspots/hotspotOnboardingSlice'
-import { getMakerName } from '../../../utils/stakingClient'
 import { RootState } from '../../../store/rootReducer'
 
 type Route = RouteProp<
@@ -114,9 +112,10 @@ const HotspotSetupBluetoothSuccess = () => {
         const networks = uniq((await readWifiNetworks(false)) || [])
         const connectedNetworks = uniq((await readWifiNetworks(true)) || [])
         const hotspotAddress = await getOnboardingAddress()
+        const onboardingRecord = await getOnboardingRecord(hotspotAddress)
+        if (!onboardingRecord) return
 
         // Save the hotspot details for later use
-        const hotspot = await getHotspotDetails(hotspotAddress)
         dispatch(
           hotspotOnboardingSlice.actions.setHotspotAddress(hotspotAddress),
         )
@@ -126,16 +125,8 @@ const HotspotSetupBluetoothSuccess = () => {
           ),
         )
         dispatch(
-          hotspotOnboardingSlice.actions.setOwnerAddress(hotspot?.owner || ''),
+          hotspotOnboardingSlice.actions.setMaker(onboardingRecord.maker),
         )
-        dispatch(
-          hotspotOnboardingSlice.actions.setMakerName(
-            getMakerName(hotspot?.payer, makers),
-          ),
-        )
-
-        const onboardingRecord = await getOnboardingRecord(hotspotAddress)
-        if (!onboardingRecord) return
 
         // navigate to next screen
         if (gatewayAction === 'addGateway') {

--- a/src/features/hotspots/setup/HotspotSetupPickLocationScreen.tsx
+++ b/src/features/hotspots/setup/HotspotSetupPickLocationScreen.tsx
@@ -89,7 +89,13 @@ const HotspotSetupPickLocationScreen = () => {
 
   const onDidFinishLoadingMap = useCallback(
     async (latitude: number, longitude: number) => {
-      const hotspot = await getHotspotDetails(params.hotspotAddress)
+      let hotspot
+      try {
+        hotspot = await getHotspotDetails(params.hotspotAddress)
+      } catch (error) {
+        console.log('Hotspot is not onboarded')
+      }
+
       const defaultLocation =
         hotspot?.lng && hotspot?.lat
           ? [hotspot?.lng, hotspot?.lat]

--- a/src/features/hotspots/setup/HotspotSetupPickWifiScreen.tsx
+++ b/src/features/hotspots/setup/HotspotSetupPickWifiScreen.tsx
@@ -96,11 +96,11 @@ const HotspotSetupPickWifiScreen = () => {
     const address = await getAddress()
 
     // Handle "404 not found" exception when onboarding new device
-    hotspot = undefined
+    let hotspot
     try {
       hotspot = await getHotspotDetails(hotspotAddress)
     } catch (error) {
-      console.log('Hotspot not found')
+      console.log('Hotspot is not onboarded')
     }
 
     if (hotspot && hotspot.owner === address) {

--- a/src/features/hotspots/setup/HotspotSetupWifiConnectingScreen.tsx
+++ b/src/features/hotspots/setup/HotspotSetupWifiConnectingScreen.tsx
@@ -53,7 +53,15 @@ const HotspotSetupWifiConnectingScreen = () => {
 
   const goToNextStep = useCallback(async () => {
     const address = await getAddress()
-    const hotspot = await getHotspotDetails(hotspotAddress)
+
+    // Check if hotspot is onboarded
+    let hotspot
+    try {
+      hotspot = await getHotspotDetails(hotspotAddress)
+    } catch (error) {
+      console.log('Hotspot is not onboarded')
+    }
+
     if (hotspot && hotspot.owner === address) {
       navigation.replace('OwnedHotspotErrorScreen')
     } else if (hotspot && hotspot.owner !== address) {

--- a/src/features/hotspots/setup/HotspotTxnsProgressScreen.tsx
+++ b/src/features/hotspots/setup/HotspotTxnsProgressScreen.tsx
@@ -48,9 +48,7 @@ const HotspotTxnsProgressScreen = () => {
   const hotspotName = useSelector(
     (state: RootState) => state.hotspotOnboarding.hotspotName,
   )
-  const makerName = useSelector(
-    (state: RootState) => state.hotspotOnboarding.makerName,
-  )
+  const maker = useSelector((state: RootState) => state.hotspotOnboarding.maker)
 
   const { track } = useAnalytics()
 
@@ -91,8 +89,6 @@ const HotspotTxnsProgressScreen = () => {
         throw new Error('Hotspot disconnected')
       }
     }
-
-    const hotspot = await getHotspotDetails(params.hotspotAddress)
 
     const updateParams = {
       token,
@@ -142,6 +138,8 @@ const HotspotTxnsProgressScreen = () => {
       })
       updateParams.assertLocationTxn = assertLocationTxn.toString()
     } else if (params.updateAntennaOnly) {
+      const hotspot = await getHotspotDetails(params.hotspotAddress)
+
       if (!hotspot.lat || !hotspot.lng) {
         // Show an alert if the hotspot location has never been asserted
         Alert.alert(
@@ -190,7 +188,7 @@ const HotspotTxnsProgressScreen = () => {
         hotspot_address: hotspotAddress,
         hotspot_name: hotspotName,
         owner_address: ownerAddress,
-        maker_name: makerName,
+        maker,
       })
     }
 
@@ -207,7 +205,7 @@ const HotspotTxnsProgressScreen = () => {
           hotspot_address: hotspotAddress,
           hotspot_name: hotspotName,
           owner_address: ownerAddress,
-          maker_name: makerName,
+          maker,
           lat,
           lng,
           decimal_gain: params.gain,

--- a/src/features/hotspots/setup/HotspotTxnsSubmitScreen.tsx
+++ b/src/features/hotspots/setup/HotspotTxnsSubmitScreen.tsx
@@ -33,9 +33,7 @@ const HotspotTxnsSubmitScreen = () => {
   const ownerAddress = useSelector(
     (state: RootState) => state.hotspotOnboarding.ownerAddress,
   )
-  const makerName = useSelector(
-    (state: RootState) => state.hotspotOnboarding.makerName,
-  )
+  const maker = useSelector((state: RootState) => state.hotspotOnboarding.maker)
   const updateAntennaOnly = useSelector(
     (state: RootState) => state.hotspotOnboarding.updateAntennaOnly,
   )
@@ -62,8 +60,7 @@ const HotspotTxnsSubmitScreen = () => {
         hotspot_type: hotspotType,
         hotspot_address: params.gatewayAddress,
         hotspot_name: hotspotName,
-        owner_address: ownerAddress,
-        maker_name: makerName,
+        maker,
         pending_transaction: {
           type: pendingTxn.type,
           txn: pendingTxn.txn,
@@ -103,7 +100,7 @@ const HotspotTxnsSubmitScreen = () => {
           hotspot_address: params.gatewayAddress,
           hotspot_name: hotspotName,
           owner_address: ownerAddress,
-          maker_name: makerName,
+          maker,
           pending_transaction: {
             type: pendingTxn.type,
             txn: pendingTxn.txn,

--- a/src/store/hotspots/hotspotOnboardingSlice.ts
+++ b/src/store/hotspots/hotspotOnboardingSlice.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { Maker } from '@helium/onboarding'
 import { MakerAntenna } from '../../makers/antennaMakerTypes'
 import { HotspotType } from '../../makers'
 
@@ -7,7 +8,7 @@ export type HotspotOnboardingState = {
   hotspotAddress?: string
   hotspotName?: string
   ownerAddress?: string
-  makerName?: string
+  maker?: Maker
   elevation?: number
   gain?: number
   antenna?: MakerAntenna
@@ -35,8 +36,8 @@ const hotspotOnboardingSlice = createSlice({
     setOwnerAddress(state, action: PayloadAction<string>) {
       state.ownerAddress = action.payload
     },
-    setMakerName(state, action: PayloadAction<string>) {
-      state.makerName = action.payload
+    setMaker(state, action: PayloadAction<Maker>) {
+      state.maker = action.payload
     },
     setElevation(state, action: PayloadAction<number>) {
       state.elevation = action.payload


### PR DESCRIPTION
**Issue**

- Link: https://github.com/NebraLtd/hm-config/issues/195
- Summary:
There are several places calling the getHotspotDetails Helium API.
For un-onboarded devices, this API call just fail and we need to handle this exception.

**How**

<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**

<!-- Include images, if possible. -->

**References**

<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names
