### PR TITLE
Display notification that Helium App must be installed from official store 2

### DIFF
--- a/src/features/onboarding/LinkAccount.tsx
+++ b/src/features/onboarding/LinkAccount.tsx
@@ -30,7 +30,7 @@ const LinkAccount = () => {
         } else {
           Alert.alert(
             'Helium App Not Found',
-            'You must have the Helium app installed from official App Store.',
+            'You must have the Helium wallet app installed using the official Android Play Store or iOS App Store.',
             [
               {
                 text: 'Cancel',


### PR DESCRIPTION
**Issue**

- Link: https://github.com/NebraLtd/maker-starter-app/issues/151
- Summary:
If Helium App installed not from the official play store, the maker app couldn't find it.
The maker app needs to display about this explicitly to the users.

**References**
- https://github.com/NebraLtd/maker-starter-app/pull/155

<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names
